### PR TITLE
Set up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
-  - "4.0.0"
-  - "0.12"
-  - "0.11"
+  - "4"
+
+install:
+  - npm install
+
+before_deploy:
+  - npm build

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ install:
 
 before_deploy:
   - npm build
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,15 @@ install:
 before_deploy:
   - npm build
 
+deploy:
+  skip_cleanup: true
+  provider: s3
+  access_key_id: $AWS_ACCESS_KEY
+  secret_access_key: $AWS_SECRET_KEY
+  bucket: "zooniverse-static"
+  upload-dir: vote.zooniverse.org
+  acl: public_read
+  local_dir: public
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,23 @@
 language: node_js
+
 node_js:
   - "4"
+
+# Requirements for Node v4
+# https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
+env:
+  - CXX=g++-4.8
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
+cache:
+  directories:
+    - node_modules
 
 install:
   - npm install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ __When you are done, create a production-ready version of the JS bundle:__
 
 ## Deployment
 
-Changes to master are deployed to S3 via [Travis-CI](https://travis-ci.org/zooniverse/vox).
+Changes to master are deployed to S3 via [Travis-CI](https://travis-ci.org/zooniverse/vox). Node dependencies are cached between builds, so if you're adding a new package, you'll need to [clear the cache in Travis](https://travis-ci.org/zooniverse/vox/caches) first.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![bitHound Score](https://www.bithound.io/github/Granze/react-starterify/badges/score.svg)](https://www.bithound.io/github/zooniverse/zoo-react-starterify/master)
-
 [![Build Status](https://travis-ci.org/zooniverse/vox.svg?branch=master)](https://travis-ci.org/zooniverse/vox)
+
+[![bitHound Overall Score](https://www.bithound.io/github/zooniverse/vox/badges/score.svg)](https://www.bithound.io/github/zooniverse/vox)
 
 # Welcome to VoX
 
@@ -23,6 +23,10 @@ __Development mode with livereload:__
 __When you are done, create a production-ready version of the JS bundle:__
 
 ```npm run build```
+
+## Deployment
+
+Changes to master are deployed to S3 via [Travis-CI](https://travis-ci.org/zooniverse/vox).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![bitHound Score](https://www.bithound.io/github/Granze/react-starterify/badges/score.svg)](https://www.bithound.io/github/zooniverse/zoo-react-starterify/master)
 
+[![Build Status](https://travis-ci.org/zooniverse/vox.svg?branch=master)](https://travis-ci.org/zooniverse/vox)
+
 # Welcome to VoX
 
 A voting client that stores users votes with Firebase, based on [Zooniverse Reduxify](https://github.com/zooniverse/zoo-reduxify).

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "start": "babel-node server.js",
-    "test": "",
+    "test": "exit 0",
     "eslint": "eslint .",
     "build": "webpack --config webpack.production.config.js -p"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "start": "babel-node server.js",
     "test": "exit 0",
     "eslint": "eslint .",
-    "build": "webpack --config webpack.production.config.js -p"
+    "build": "webpack --config webpack.production.config.js -p",
+    "deploy-preview": "npm run build && publisssh dist zooniverse-static/vote-preview.zooniverse.org/"
   },
   "author": "Zooniverse",
   "license": "Apache-2.0",
@@ -36,6 +37,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "firebase": "^3.0.4",
     "history": "^1.13.1",
+    "publisssh": "^1.1.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-redux": "^4.4.5",


### PR DESCRIPTION
This sets up Travis for automated deployment to S3 (to vote.zooniverse.org). I've generated a new set of credentials under my AWS user for this, so can revoke them if needed. Build time is around a 1m30, as I've cached the `node_modules` folder - if you're adding new deps, you'll need to clear the cache before rebuilding.
